### PR TITLE
fix: handle error if getNextUrl throws

### DIFF
--- a/reconnecting-websocket.ts
+++ b/reconnecting-websocket.ts
@@ -387,7 +387,11 @@ export default class ReconnectingWebSocket {
                 this._addListeners();
 
                 this._connectTimeout = setTimeout(() => this._handleTimeout(), connectionTimeout);
-            });
+            })
+            .catch(err => {
+                this._connectLock = false;
+                this._handleError(new Events.ErrorEvent(Error(err.message), this))
+            })
     }
 
     private _handleTimeout() {


### PR DESCRIPTION
picked from https://github.com/pladaria/reconnecting-websocket/pull/166
